### PR TITLE
pre-mature dealloc

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -513,6 +513,7 @@
     [self log:@"setTimeout()"];
     if (_timeout != nil) 
     {   
+        [[self retain] autorelease]; //Prevent self from being dealloc'd if _timeout is the only one retaining it
         [_timeout invalidate];
         [_timeout release];
         _timeout = nil;


### PR DESCRIPTION
Under -setTimeout, self gets dealloc'd when [_timeout invalidate] gets called. Subsequently the line after that, [_timeout release] will cause a crash because of over releasing.

This happens when we release the SocketIO object gets released before -onDisconnect gets called. In that case _timeout is the only object retaining the SocketIO object.

Perhaps you have a better fix, but this seems to work for me.
