### PR TITLE
Allocated _httpRequestData

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -70,7 +70,7 @@
         _queue = [[NSMutableArray alloc] init];
         _ackCount = 0;
         _acks = [[NSMutableDictionary alloc] init]; 
-        _httpRequestData = [NSMutableData data];
+        _httpRequestData = [[NSMutableData alloc] init];
     }
     return self;
 }


### PR DESCRIPTION
Prior to having allocated this instance of NSMutableData, I was receiving EXC_BAD_ACCESS while connecting to the socket.io server.
