### PR TITLE
Added String formats with no port and connected state check

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -46,6 +46,7 @@ typedef void(^SocketIOCallback)(id argsData);
     NSInteger _port;
     NSString *_sid;
     NSString *_endpoint;
+    NSDictionary *_params;
     
     __unsafe_unretained id<SocketIODelegate> _delegate;
     

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -104,6 +104,7 @@ static NSString* kSecureXHRPortURL = @"https://%@:%d/socket.io/1/xhr-polling/%@"
         
         _host = host;
         _port = port;
+        _params = params;
         _endpoint = [endpoint copy];
         
         // create a query parameters string
@@ -611,6 +612,12 @@ static NSString* kSecureXHRPortURL = @"https://%@:%d/socket.io/1/xhr-polling/%@"
     
     _sid = [data objectAtIndex:0];
     [self log:[NSString stringWithFormat:@"sid: %@", _sid]];
+    NSString *regex = @"[^0-9]";
+    NSPredicate *regexTest = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", regex];
+    if ([_sid rangeOfString:@"error"].location != NSNotFound || [regexTest evaluateWithObject:_sid]) {
+        [self connectToHost:_host onPort:_port withParams:_params withNamespace:_endpoint];
+        return;
+    }
     
     // add small buffer of 7sec (magic xD)
     _heartbeatTimeout = [[data objectAtIndex:1] floatValue] + 7.0;


### PR DESCRIPTION
This is useful when using providers such as Heroku and Nodejitsu where applications listen on specific ports through a routing mesh.

For example: https://example.com:443/socket.io does not work on Nodejitsu, but https://example.com/socket.io does.

Its a nuance in the routing meshes where the port is considered part of the application name, but using https and port 80 has issues with proxies and firewalls which https does not.

Specifying a port of 0, uses the protocols default

When sending we need to check the sockets ready state as the NSStream can end, triggering a ready state change but the multithreaded architecture means we can call send on a broken socket since the disconnect message has not propagated.
