### PR TITLE
More graceful connection failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@
 	- (void) socketIO:(SocketIO *)socket didReceiveJSON:(SocketIOPacket *)packet;
 	- (void) socketIO:(SocketIO *)socket didReceiveEvent:(SocketIOPacket *)packet;
 	- (void) socketIO:(SocketIO *)socket didSendMessage:(SocketIOPacket *)packet;
+	- (void) socketIOHandshakeFailed:(SocketIO *)socket;
+	- (void) socketIO:(SocketIO *)socket failedToConnectWithError:(NSError *)error;
 
   To process an incoming Message just
 

--- a/SocketIO.h
+++ b/SocketIO.h
@@ -28,6 +28,12 @@
 
 typedef void(^SocketIOCallback)(id argsData);
 
+extern NSString* const SocketIOError;
+
+typedef enum {
+    SocketIOServerRespondedWithInvalidConnectionData = -1
+} SocketIOErrorCodes;
+
 @protocol SocketIODelegate <NSObject>
 @optional
 - (void) socketIODidConnect:(SocketIO *)socket;
@@ -37,6 +43,7 @@ typedef void(^SocketIOCallback)(id argsData);
 - (void) socketIO:(SocketIO *)socket didReceiveEvent:(SocketIOPacket *)packet;
 - (void) socketIO:(SocketIO *)socket didSendMessage:(SocketIOPacket *)packet;
 - (void) socketIOHandshakeFailed:(SocketIO *)socket;
+- (void) socketIO:(SocketIO *)socket failedToConnectWithError:(NSError *)error;
 @end
 
 


### PR DESCRIPTION
On my very first connection attempt, this code threw an exception.  This was caused by
some assumptions about the array length in -[SocketIO connectionDidFinishLoading:].  I took
the liberty of adding some sanity checks to prevent the crash and hooking those up to new
delegate API to communicate the failure.

Also updated README.md accordingly - and snuck in another missing delegate method.
