### PR TITLE
Fix for totally bogus interface declaration

### DIFF
--- a/SocketIOJSONSerialization.h
+++ b/SocketIOJSONSerialization.h
@@ -22,7 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface SocketIOJSONSerialization
+@interface SocketIOJSONSerialization : NSObject
 
 + (id) objectFromJSONData:(NSData *)data error:(NSError **)error;
 + (NSString *) JSONStringFromObject:(id)object error:(NSError **)error;


### PR DESCRIPTION
In my rush to refactor JSON serialization, I made a new class that doesn't inherit from NSObject.  Why this
is a) allowed, b) doesn't result in epic failure on OS X is beyond me.
