### PR TITLE
Make sendEvent conform to current socket.io protocol

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -191,7 +191,7 @@ NSString* const SocketIOException = @"SocketIOException";
 
     // do not require arguments
     if (data != nil) {
-        [dict setObject:data forKey:@"args"];
+        [dict setObject:[NSArray arrayWithObject:data] forKey:@"args"];
     }
     
     SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"event"];


### PR DESCRIPTION
As per https://github.com/LearnBoost/socket.io-spec/blob/master/README.md,

---

(5) Event

'5:' [message id ('+')] ':' [message endpoint] ':' [json encoded event]
## An event is like a json message, but has mandatory name and args fields. name is a string and args an array.

Right now 'args' is not an array (rather a dict), thus not working correctly when connecting to behaving socket.io servers.

Provided is a simple patch that addresses this issue.
