### PR TITLE
Remove delegate reference to SocketIOTransportWebsocket on dealloc

### DIFF
--- a/SocketIOTransportWebsocket.m
+++ b/SocketIOTransportWebsocket.m
@@ -77,6 +77,10 @@ static NSString* kSecureSocketPortURL = @"wss://%@:%d/socket.io/1/websocket/%@";
     [_webSocket open];
 }
 
+- (void)dealloc {
+    [_webSocket setDelegate:NULL];
+}
+
 - (void) close
 {
     [_webSocket close];


### PR DESCRIPTION
This is a fix for https://github.com/pkyeck/socket.IO-objc/issues/64. SocketIOTransportWebsocket as a delegate was still being sent messages even after dealloc.
