### PR TITLE
No need to invalidate a non repeating timer

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -364,7 +364,6 @@ NSString* const SocketIOException = @"SocketIOException";
 {
     DEBUGLOG(@"start/reset timeout");
     if (_timeout != nil) {
-        [_timeout invalidate];
         _timeout = nil;
     }
     


### PR DESCRIPTION
It invalidates itself.
