### PR TITLE
Option to change resource name

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -75,6 +75,8 @@ typedef enum {
     BOOL _isConnecting;
     BOOL _useSecure;
     
+    NSString* _resource;
+    
     NSURLConnection *_handshake;
     
     // heartbeat
@@ -96,6 +98,7 @@ typedef enum {
 @property (nonatomic, readonly) NSString *sid;
 @property (nonatomic, readonly) NSTimeInterval heartbeatTimeout;
 @property (nonatomic) BOOL useSecure;
+@property (nonatomic, copy) NSString* resource;
 @property (nonatomic, readonly) BOOL isConnected, isConnecting;
 @property (nonatomic, unsafe_unretained) id<SocketIODelegate> delegate;
 

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -75,7 +75,8 @@ NSString* const SocketIOException = @"SocketIOException";
 
 @synthesize isConnected = _isConnected, 
             isConnecting = _isConnecting, 
-            useSecure = _useSecure, 
+            useSecure = _useSecure,
+            resource = _resource,
             delegate = _delegate,
             heartbeatTimeout = _heartbeatTimeout;
 
@@ -128,6 +129,10 @@ NSString* const SocketIOException = @"SocketIOException";
             format = _useSecure ? kSecureHandshakeURL : kInsecureHandshakeURL;
             s = [NSString stringWithFormat:format, _host, rand(), query];
         }
+        if (_resource != nil) {
+            s = [s stringByReplacingOccurrencesOfString:@"socket.io" withString:_resource];
+        }
+        
         DEBUGLOG(@"Connecting to socket with URL: %@", s);
         NSURL *url = [NSURL URLWithString:s];
         query = nil;

--- a/SocketIOTransportWebsocket.m
+++ b/SocketIOTransportWebsocket.m
@@ -67,6 +67,12 @@ static NSString* kSecureSocketPortURL = @"wss://%@:%d/socket.io/1/websocket/%@";
         format = delegate.useSecure ? kSecureSocketURL : kInsecureSocketURL;
         urlStr = [NSString stringWithFormat:format, delegate.host, delegate.sid];
     }
+    
+    SocketIO* socketio = (SocketIO*)self.delegate;
+    if (socketio.resource != nil) {
+        urlStr = [urlStr stringByReplacingOccurrencesOfString:@"socket.io" withString:socketio.resource];
+    }
+    
     NSURL *url = [NSURL URLWithString:urlStr];
     
     _webSocket = nil;

--- a/SocketIOTransportXHR.m
+++ b/SocketIOTransportXHR.m
@@ -69,6 +69,12 @@ static NSString* kSecureXHRPortURL = @"https://%@:%d/socket.io/1/xhr-polling/%@"
         format = delegate.useSecure ? kSecureXHRURL : kInsecureXHRURL;
         _url = [NSString stringWithFormat:format, delegate.host, delegate.sid];
     }
+
+    SocketIO* socketio = (SocketIO*)self.delegate;
+    if (socketio.resource != nil) {
+        _url = [_url stringByReplacingOccurrencesOfString:@"socket.io" withString:socketio.resource];
+    }
+
     DEBUGLOG(@"Opening XHR @ %@", _url);
     [self poll:nil];
 }


### PR DESCRIPTION
Added the option to change the default socket.io resource name:

``` objective-c
socket = [[SocketIO alloc] initWithDelegate:self];
socket.resource = @"whatever";
socket.useSecure = YES;
```

So, urls can be like this:
http://SERVER:PORT/whatever/1/?t=
