### PR TITLE
Fix integer precision warning

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -583,7 +583,7 @@ NSString* const SocketIOException = @"SocketIOException";
 {
     // check for server status code (http://gigliwood.com/weblog/Cocoa/Q__When_is_an_conne.html)
     if ([response respondsToSelector:@selector(statusCode)]) {
-        int statusCode = [((NSHTTPURLResponse *)response) statusCode];
+        NSInteger statusCode = [((NSHTTPURLResponse *)response) statusCode];
         DEBUGLOG(@"didReceiveResponse() %i", statusCode);
         
         if (statusCode >= 400) {


### PR DESCRIPTION
When building on x86_64, statusCode is not an int.  Using NSInteger here will work on all architectures.
