### PR TITLE
Send all arguments to the callback, not just the first one

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -500,9 +500,6 @@ NSString* const SocketIOException = @"SocketIOException";
                     id argsData = nil;
                     if (argsStr && ![argsStr isEqualToString:@""]) {
                         argsData = [SocketIOJSONSerialization objectFromJSONData:[argsStr dataUsingEncoding:NSUTF8StringEncoding] error:nil];
-                        if ([argsData count] > 0) {
-                            argsData = [argsData objectAtIndex:0];
-                        }
                     }
                     
                     // get selector for ackId


### PR DESCRIPTION
In our app, we send back three arguments: an error message, the data, and a code.

I would argue that we send all arguments to the callback, not just the first, especially because it looks like socket.io.js does it this way (https://github.com/LearnBoost/socket.io/blob/master/lib/socket.js#L318).
