### PR TITLE
Addresses Issue 76

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -138,8 +138,11 @@ NSString* const SocketIOException = @"SocketIOException";
                                                  cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData 
                                              timeoutInterval:10.0];
         
-        _handshake = [NSURLConnection connectionWithRequest:request 
-                                                   delegate:self];
+        _handshake = [[NSURLConnection alloc] initWithRequest:request
+                                                     delegate:self startImmediately:NO];
+        [_handshake scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                              forMode:NSDefaultRunLoopMode];
+        [_handshake start];
         if (_handshake) {
             _httpRequestData = [NSMutableData data];
         }


### PR DESCRIPTION
This patch should fix https://github.com/pkyeck/socket.IO-objc/issues/76

I was seeing a similar problem and found this SO post which details the fix:
http://stackoverflow.com/questions/5787170/nsurlconnection-delegate-methods-are-not-called
