### PR TITLE
Disconnect error flood when using XHR.

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -248,7 +248,7 @@ NSString* const SocketIOException = @"SocketIOException";
 
 - (void) send:(SocketIOPacket *)packet
 {
-    if(![self isConnected]) {
+    if(![self isConnected] && ![self isConnecting]) {
         DEBUGLOG(@"Already disconnected!");
         return;
     }


### PR DESCRIPTION
Sometimes when disconnecting the socket, there's a flood of messages in the log (see below) and the disconnect isn't handled properly and the -[SocketIODelegate socketIODidDisconnect: disconnectedWithError:]  callback on the delegate isn't called (causing the calling app to not cleanup up the resources).

I checked the javascript socket.io client and there the socket.io connection is destroyed immediately after sending the disconnect packet https://github.com/LearnBoost/socket.io-client/blob/master/lib/socket.js#L342). I ported this behavior to socket.IO-objc.

Log flood:

```
send()
send() >>> 0::
onData 8::
start/reset timeout
noop
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
error
onData 7:::1+0
start/reset timeout
```
