### PR TITLE
Add initial connection timeout

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -107,6 +107,8 @@ typedef enum {
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port;
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params;
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params withNamespace:(NSString *)endpoint;
+- (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params withNamespace:(NSString *)endpoint withConnectionTimeout: (NSTimeInterval) connectionTimeout;
+
 - (void) disconnect;
 
 - (void) sendMessage:(NSString *)data;

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -95,15 +95,19 @@ NSString* const SocketIOException = @"SocketIOException";
 
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port
 {
-    [self connectToHost:host onPort:port withParams:nil withNamespace:@""];
+    [self connectToHost:host onPort:port withParams:nil withNamespace:@"" withConnectionTimeout:10.0f];
 }
 
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params
 {
-    [self connectToHost:host onPort:port withParams:params withNamespace:@""];
+    [self connectToHost:host onPort:port withParams:params withNamespace:@"" withConnectionTimeout:10.0f];
 }
 
-- (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params withNamespace:(NSString *)endpoint
+- (void)connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params withNamespace:(NSString *)endpoint {
+    [self connectToHost:host onPort:port withParams:params withNamespace:@"" withConnectionTimeout:10.0f];
+}
+
+- (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params withNamespace:(NSString *)endpoint withConnectionTimeout:(NSTimeInterval)connectionTimeout
 {
     if (!_isConnected && !_isConnecting) {
         _isConnecting = YES;
@@ -138,7 +142,7 @@ NSString* const SocketIOException = @"SocketIOException";
         // make a request
         NSURLRequest *request = [NSURLRequest requestWithURL:url
                                                  cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData 
-                                             timeoutInterval:10.0];
+                                             timeoutInterval:connectionTimeout];
         
         _handshake = [[NSURLConnection alloc] initWithRequest:request
                                                      delegate:self startImmediately:NO];


### PR DESCRIPTION
I added an optional parameter to the "connectTo..."-method. This ways it's possible to use a longer timeout interval on the initial socket.io request. This is especially handy when the client is connecting with a slow mobile internet connection
