### PR TITLE
Fix crash on disconnect & deallocation

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -764,7 +764,7 @@ didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 
 - (void) dealloc
 {
-    _handshake.delegate = nil;
+    [_handshake cancel];
     _handshake = nil;
 
     _host = nil;


### PR DESCRIPTION
Hi!

In my project I got crashes in -onData: and timer callbacks in SocketIO.m after I called -disconnect on it & released the socket.

I fixed it fo myself by these patches, looks like the main thing was that -onDisconnect: was never called if you're using -disconnect

Hope it helps.
If you want something be made differently - I would love to update the pull request.

Thanks!

P.S.
Now I see that this may look as part of #106, although I haven't experienced flood and simply fixed the crashes.
