### PR TITLE
Add support for synchronous disconnect

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -108,6 +108,7 @@ typedef enum {
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params;
 - (void) connectToHost:(NSString *)host onPort:(NSInteger)port withParams:(NSDictionary *)params withNamespace:(NSString *)endpoint;
 - (void) disconnect;
+- (void) disconnectSync;
 
 - (void) sendMessage:(NSString *)data;
 - (void) sendMessage:(NSString *)data withAcknowledge:(SocketIOCallback)function;

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -165,6 +165,24 @@ NSString* const SocketIOException = @"SocketIOException";
     }
 }
 
+- (void)disconnectSync {
+    NSString *protocol = [self useSecure] ? @"https" : @"http";
+    NSString *urlString = [NSString stringWithFormat:@"%@://%@:%i/socket.io/1/xhr-polling/%@?disconnect", protocol, _host, _port, _sid];
+    NSURL *url = [NSURL URLWithString:urlString];
+    
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    NSError *error = nil;
+    NSHTTPURLResponse *response = nil;
+    
+    [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+    
+    if(error || [response statusCode] != 200) {
+        DEBUGLOG(@"Error during disconnect: %@", error);
+    }
+    
+    [self onDisconnect:error];
+}
+
 - (void) sendMessage:(NSString *)data
 {
     [self sendMessage:data withAcknowledge:nil];


### PR DESCRIPTION
I'm using the code (using the xhr transport) in an iPhone project. When the apps go to the background, I'm using beginBackgroundTaskWithExpirationHandler to keep the socket.io connection open in the background, allowing me to receive (for a limited time) events from the socket.io server.
When the background task is expiring I'm disconnecting the socket, calling endBackgroundTask in the socketIODidDisconnect-method of my delegate.

The problem with this scenario is that the package containing the disconnect isn't send before the background task is ended.

Using a sync-disconnect I make sure that the socket.io server 'knows' about the disconnect. (see the following socket.io specs: https://github.com/LearnBoost/socket.io-spec#forced-socket-disconnection).
