### PR TITLE
Debugging always enabled

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -28,8 +28,13 @@
 #import "SocketIOTransportWebsocket.h"
 #import "SocketIOTransportXHR.h"
 
+#ifdef DEBUG
 #define DEBUG_LOGS 1
 #define DEBUG_CERTIFICATE 1
+#else
+#define DEBUG_LOGS 0
+#define DEBUG_CERTIFICATE 0
+#endif
 
 #if DEBUG_LOGS
 #define DEBUGLOG(...) NSLog(__VA_ARGS__)


### PR DESCRIPTION
Debugging should only happen if it is build for debugging (DEBUG is defined if compiled by XCODE for debugging/not release).
