### PR TITLE
Fix missing endpoint parameter in one of -connect methods.

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -109,7 +109,7 @@ NSString* const SocketIOException = @"SocketIOException";
             withParams:(NSDictionary *)params
          withNamespace:(NSString *)endpoint
 {
-    [self connectToHost:host onPort:port withParams:params withNamespace:@"" withConnectionTimeout:defaultConnectionTimeout];
+    [self connectToHost:host onPort:port withParams:params withNamespace:endpoint withConnectionTimeout:defaultConnectionTimeout];
 }
 
 - (void) connectToHost:(NSString *)host


### PR DESCRIPTION
Hi! You seem to forget to pass the `endpoint` parameter from one of the `-connectWith:...` methods to the actual implementation.

Cheers.
