### PR TITLE
[FIX] namespace param

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -109,7 +109,7 @@ NSString* const SocketIOException = @"SocketIOException";
             withParams:(NSDictionary *)params
          withNamespace:(NSString *)endpoint
 {
-    [self connectToHost:host onPort:port withParams:params withNamespace:@"" withConnectionTimeout:defaultConnectionTimeout];
+    [self connectToHost:host onPort:port withParams:params withNamespace:endpoint withConnectionTimeout:defaultConnectionTimeout];
 }
 
 - (void) connectToHost:(NSString *)host


### PR DESCRIPTION
Hi,

I fixed a little bug (certainly due to a copy/paste) on the `connectToHost:onPort:withParams:withNamespace:` method.

Best,
Yannick
