### PR TITLE
Fix improper use of NSLocalizedDescriptionKey.

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -676,7 +676,7 @@ NSString* const SocketIOException = @"SocketIOException";
     _isConnecting = NO;
     
     if ([_delegate respondsToSelector:@selector(socketIO:onError:)]) {
-        NSMutableDictionary *errorInfo = [NSDictionary dictionaryWithObject:error forKey:NSLocalizedDescriptionKey];
+        NSMutableDictionary *errorInfo = [NSDictionary dictionaryWithObject:error forKey:NSUnderlyingErrorKey];
         
         NSError *err = [NSError errorWithDomain:SocketIOError
                                            code:SocketIOHandshakeFailed


### PR DESCRIPTION
This commit fixes a typo where an underlying error (`NSError` object) was associated with `NSLocalizedDescriptionKey` that is expected to be `NSString` (so it crashed `UIAlertView` with `error.localizedString` as a parameter).
