### PR TITLE
Make transports dynamic loadable (based on available classes)

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -25,9 +25,6 @@
 #import "SocketIOPacket.h"
 #import "SocketIOJSONSerialization.h"
 
-#import "SocketIOTransportWebsocket.h"
-#import "SocketIOTransportXHR.h"
-
 #define DEBUG_LOGS 1
 #define DEBUG_CERTIFICATE 1
 
@@ -739,13 +736,25 @@ NSString* const SocketIOException = @"SocketIOException";
         NSArray *transports = [t componentsSeparatedByString:@","];
         DEBUGLOG(@"transports: %@", transports);
         
-        if ([transports indexOfObject:@"websocket"] != NSNotFound) {
-            DEBUGLOG(@"websocket supported -> using it now");
-            _transport = [[SocketIOTransportWebsocket alloc] initWithDelegate:self];
+        static Class webSocketTransportClass;
+        static Class xhrTransportClass;
+        
+        if(webSocketTransportClass == nil) {
+            webSocketTransportClass = NSClassFromString(@"SocketIOTransportWebsocket");
         }
-        else if ([transports indexOfObject:@"xhr-polling"] != NSNotFound) {
+        if(xhrTransportClass == nil) {
+            xhrTransportClass = NSClassFromString(@"SocketIOTransportXHR");
+        }
+        
+        
+        
+        if (webSocketTransportClass != nil && [transports indexOfObject:@"websocket"] != NSNotFound) {
+            DEBUGLOG(@"websocket supported -> using it now");
+            _transport = [[webSocketTransportClass alloc] initWithDelegate:self];
+        }
+        else if (xhrTransportClass != nil && [transports indexOfObject:@"xhr-polling"] != NSNotFound) {
             DEBUGLOG(@"xhr polling supported -> using it now");
-            _transport = [[SocketIOTransportXHR alloc] initWithDelegate:self];
+            _transport = [[xhrTransportClass alloc] initWithDelegate:self];
         }
         else {
             DEBUGLOG(@"no transport found that is supported :( -> fail");


### PR DESCRIPTION
I have a project where I only support XHR. By changing the SocketIOTransport initialization to "dynamically" load the neccessary (& supported) classes, I don't have to include SRWebSocket in my builds (which results in less unused code and a smaller binary).
