### PR TITLE
Remove acknowledge before calling block

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -570,8 +570,8 @@ NSString* const SocketIOException = @"SocketIOException";
                     NSString *key = [NSString stringWithFormat:@"%d", ackId];
                     SocketIOCallback callbackFunction = [_acks objectForKey:key];
                     if (callbackFunction != nil) {
-                        callbackFunction(argsData);
                         [self removeAcknowledgeForKey:key];
+                        callbackFunction(argsData);
                     }
                 }
                 


### PR DESCRIPTION
Acknowledge should be deleted before calling the block, in case I disconnect the socket in such block.
This was causing an EXC BAD ACCESS error.
