### PR TITLE
allow multiple parameters

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -115,6 +115,8 @@ typedef enum {
 - (void) sendJSON:(NSDictionary *)data withAcknowledge:(SocketIOCallback)function;
 - (void) sendEvent:(NSString *)eventName withData:(id)data;
 - (void) sendEvent:(NSString *)eventName withData:(id)data andAcknowledge:(SocketIOCallback)function;
+- (void) sendEvent:(NSString *)eventName withMultepleData:(NSArray *)list;
+- (void) sendEvent:(NSString *)eventName withMultepleData:(NSArray *)list andAcknowledge:(SocketIOCallback)function;
 - (void) sendAcknowledgement:(NSString*)pId withArgs:(NSArray *)data;
 
 - (void) setResourceName:(NSString *)name;

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -249,6 +249,25 @@ NSString* const SocketIOException = @"SocketIOException";
     [self send:packet];
 }
 
+- (void) sendEvent:(NSString *)eventName withMultepleData:(NSArray *)list
+{
+    [self sendEvent:eventName withMultepleData:list andAcknowledge:nil];
+}
+
+- (void) sendEvent:(NSString *)eventName withMultepleData:(NSArray *)list andAcknowledge:(SocketIOCallback)function
+{
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:eventName forKey:@"name"];
+    
+    [dict setObject:list forKey:@"args"];
+    SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"event"];
+    packet.data = [SocketIOJSONSerialization JSONStringFromObject:dict error:nil];
+    packet.pId = [self addAcknowledge:function];
+    if (function) {
+        packet.ack = @"data";
+    }
+    [self send:packet];
+}
+
 - (void) sendAcknowledgement:(NSString *)pId withArgs:(NSArray *)data 
 {
     SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"ack"];


### PR DESCRIPTION
Since JS client allows multiple parameters, perhaps we should allow the same behavior in obj-c?

``` JavaScript

socket.emit('eventName', 'foo', 'bar', {baz: 'nyan'});
```
