### PR TITLE
Acknowledgment timeout (#124)

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -111,10 +111,13 @@ typedef enum {
 
 - (void) sendMessage:(NSString *)data;
 - (void) sendMessage:(NSString *)data withAcknowledge:(SocketIOCallback)function;
+- (void) sendMessage:(NSString *)data withAcknowledge:(SocketIOCallback)function withTimeout:(NSTimeInterval)timeout;
 - (void) sendJSON:(NSDictionary *)data;
 - (void) sendJSON:(NSDictionary *)data withAcknowledge:(SocketIOCallback)function;
+- (void) sendJSON:(NSDictionary *)data withAcknowledge:(SocketIOCallback)function withTimeout:(NSTimeInterval)timeout;
 - (void) sendEvent:(NSString *)eventName withData:(id)data;
 - (void) sendEvent:(NSString *)eventName withData:(id)data andAcknowledge:(SocketIOCallback)function;
+- (void) sendEvent:(NSString *)eventName withData:(id)data andAcknowledge:(SocketIOCallback)function withTimeout:(NSTimeInterval)timeout;
 - (void) sendAcknowledgement:(NSString*)pId withArgs:(NSArray *)data;
 
 - (void) setResourceName:(NSString *)name;


### PR DESCRIPTION
Current implementation that I use in my applications.
If server does not respond with and acknowledgment (e.g. server crashed) it allows to release blocks and all retained variables after a timeout. NSTimer is used instead of dispatch_queue to simplify the implementation.
