### PR TITLE
Remove an unnecessary ivar declaration 

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -61,8 +61,6 @@ typedef enum {
     NSString *_endpoint;
     NSDictionary *_params;
     
-    __weak id<SocketIODelegate> _delegate;
-    
     NSObject <SocketIOTransport> *_transport;
     
     BOOL _isConnected;


### PR DESCRIPTION
This yielded a build error `the current deployment target does not support automated __weak references` on iOS 8 and possibly on other platforms. Fixes #187.
