### PR TITLE
Allow to send NSArray as event args

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -237,7 +237,10 @@ NSString* const SocketIOException = @"SocketIOException";
 
     // do not require arguments
     if (data != nil) {
-        [dict setObject:[NSArray arrayWithObject:data] forKey:@"args"];
+        if (![data isKindOfClass:[NSArray class]]) {
+            data = [NSArray arrayWithObject:data];
+        }
+        [dict setObject:data forKey:@"args"];
     }
     
     SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"event"];


### PR DESCRIPTION
Please pull this in. I have had these change in our production app "Jaumo" for about a year. We needed this as we have to send an array for user authentication to our backend.
It is a bit annoying to manually add these changes each time I update from your repo.

Thanks a lot!
