### PR TITLE
Fix namespace to use the same socket connection with multiple namespaces.

### DIFF
--- a/SocketIONamespace.h
+++ b/SocketIONamespace.h
@@ -1,0 +1,55 @@
+//
+//  SocketIONamespace.h
+//
+//  Created by jbaez https://github.com/jbaez on 04/07/2014.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "SocketIO_NSInterface.h"
+
+@interface SocketIONamespace : NSObject <SocketIOProtocol, SocketIONamespaceDelegate>
+{
+    __weak id<SocketIODelegate> _delegate;
+}
+
+/// The namespace enpoint
+@property (nonatomic, strong, readonly) NSString *endpoint;
+
+/// SocketIO delegate for this namespace
+@property (nonatomic, weak) id<SocketIODelegate> delegate;
+
+/// Shared socket instance
+@property (nonatomic, strong, readonly) SocketIO *socket;
+
+/// Namespace connection instance
++ (instancetype)namespaceWithEndpoint:(NSString *)endpoint
+                             delegate:(id<SocketIODelegate>)delegate;
+
+/// Namespace connection instance
++ (instancetype)namespaceWithEndpoint:(NSString *)endpoint;
+
+/// Shared socket used for namespace connections
++ (SocketIO *)sharedSocket;
+
+#pragma mark - SocketIOProtocol
+
+- (void)connectToHost:(NSString *)host onPort:(NSInteger)port;
+- (void)connectToHost:(NSString *)host
+               onPort:(NSInteger)port
+           withParams:(NSDictionary *)params;
+- (void)connectToHost:(NSString *)host
+               onPort:(NSInteger)port
+           withParams:(NSDictionary *)params
+withConnectionTimeout:(NSTimeInterval)connectionTimeout;
+
+- (void)sendMessage:(NSString *)data;
+- (void)sendMessage:(NSString *)data withAcknowledge:(SocketIOCallback)function;
+- (void)sendJSON:(NSDictionary *)data;
+- (void)sendJSON:(NSDictionary *)data withAcknowledge:(SocketIOCallback)function;
+- (void)sendEvent:(NSString *)eventName withData:(id)data;
+- (void)sendEvent:(NSString *)eventName
+         withData:(id)data
+   andAcknowledge:(SocketIOCallback)function;
+
+@end

--- a/SocketIONamespace.m
+++ b/SocketIONamespace.m
@@ -1,0 +1,214 @@
+//
+//  SocketIONamespace.m
+//
+//  Created by jbaez https://github.com/jbaez on 04/07/2014.
+//
+//
+
+#import "SocketIONamespace.h"
+#import "SocketIOPacket.h"
+
+@interface SocketIONamespace()
+
+@property (nonatomic, strong) SocketIO *socket;
+@property (nonatomic, strong) NSString *endpoint;
+
+@end
+
+@implementation SocketIONamespace
+
+#pragma mark - initializers
+
++ (SocketIO *)sharedSocket
+{
+    static SocketIO *socket;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        socket = [[SocketIO alloc] init];
+    });
+
+    return socket;
+}
+
++ (instancetype)namespaceWithEndpoint:(NSString *)endpoint
+                             delegate:(id<SocketIODelegate>)delegate
+{
+    SocketIO *socket = [SocketIONamespace sharedSocket];
+
+    SocketIONamespace *namespace = [[SocketIONamespace alloc] initWithSocket:socket
+                                                                   namespace:endpoint
+                                                                    delegate:delegate];
+
+    return namespace;
+}
+
++ (instancetype)namespaceWithEndpoint:(NSString *)endpoint
+{
+    SocketIO *socket = [SocketIONamespace sharedSocket];
+
+    SocketIONamespace *namespace = [[SocketIONamespace alloc] initWithSocket:socket
+                                                                   namespace:endpoint
+                                                                    delegate:nil];
+
+    return namespace;
+}
+
+/// Private initializer
+- (instancetype)initWithSocket:(SocketIO *)socket
+                     namespace:(NSString *)endpoint
+                      delegate:(id<SocketIODelegate>)delegate
+{
+    self = [super init];
+    if (self) {
+        _socket = socket;
+        _endpoint = endpoint;
+        _delegate = delegate;
+
+        [_socket addNamespaceDelegate:self];
+    }
+    return self;
+}
+
+#pragma mark - private methods
+
+- (void)sendConnectPackage
+{
+    if([self.socket isConnected] && ![self.socket isConnecting]) {
+        // socket already connected. Send connect package for new namespace
+        [self.socket sendConnectForNamespace:self.endpoint];
+    }
+}
+
+#pragma mark - SocketIOProtocol
+
+- (void)connectToHost:(NSString *)host onPort:(NSInteger)port
+{
+    if (![self.socket isConnected] && ![self.socket isConnecting]) {
+        [self.socket connectToHost:host
+                            onPort:port];
+    } else {
+        // socket already connected. Send connect package for new namespace
+        [self sendConnectPackage];
+    }
+}
+
+- (void)connectToHost:(NSString *)host
+               onPort:(NSInteger)port
+           withParams:(NSDictionary *)params
+{
+    if (![self.socket isConnected] && ![self.socket isConnecting]) {
+        [self.socket connectToHost:host
+                            onPort:port
+                        withParams:params];
+    } else {
+        // socket already connected. Send connect package for new namespace
+        [self sendConnectPackage];
+    }
+}
+
+- (void)connectToHost:(NSString *)host
+               onPort:(NSInteger)port
+           withParams:(NSDictionary *)params
+withConnectionTimeout:(NSTimeInterval)connectionTimeout
+{
+    if (![self.socket isConnected] && ![self.socket isConnecting]) {
+        [self.socket connectToHost:host
+                            onPort:port
+                        withParams:params
+             withConnectionTimeout:connectionTimeout];
+    } else {
+        // socket already connected. Send connect package for new namespace
+        [self sendConnectPackage];
+    }
+}
+
+- (void)sendMessage:(NSString *)data
+{
+    [self.socket sendMessage:data forNamespace:self.endpoint];
+}
+
+- (void)sendMessage:(NSString *)data withAcknowledge:(SocketIOCallback)function
+{
+    [self.socket sendMessage:data forNamespace:self.endpoint withAcknowledge:function];
+}
+
+- (void)sendJSON:(NSDictionary *)data
+{
+    [self.socket sendJSON:data forNamespace:self.endpoint];
+}
+
+- (void)sendJSON:(NSDictionary *)data withAcknowledge:(SocketIOCallback)function
+{
+    [self.socket sendJSON:data forNamespace:self.endpoint withAcknowledge:function];
+}
+
+- (void)sendEvent:(NSString *)eventName withData:(id)data
+{
+    [self.socket sendEvent:eventName forNamespace:self.endpoint withData:data];
+}
+
+- (void)sendEvent:(NSString *)eventName
+         withData:(id)data
+   andAcknowledge:(SocketIOCallback)function
+{
+    [self.socket sendEvent:eventName
+              forNamespace:self.endpoint
+                  withData:data
+            andAcknowledge:function];
+}
+
+#pragma mark - socketIONamespace delegate protocol
+
+- (void)socketIODidConnect:(SocketIO *)socket
+{
+    if ([_delegate respondsToSelector:@selector(socketIODidConnect:)]) {
+        [_delegate socketIODidConnect:socket];
+    }
+}
+
+- (void)socketIODidDisconnect:(SocketIO *)socket disconnectedWithError:(NSError *)error
+{
+    if ([_delegate respondsToSelector:@selector(socketIODidDisconnect:
+                                                disconnectedWithError:)]) {
+        [_delegate socketIODidDisconnect:socket
+                   disconnectedWithError:error];
+    }
+}
+
+- (void)socketIO:(SocketIO *)socket didReceiveMessage:(SocketIOPacket *)packet
+{
+    if ([_delegate respondsToSelector:@selector(socketIO:didReceiveMessage:)]) {
+        [_delegate socketIO:socket didReceiveMessage:packet];
+    }
+}
+
+- (void)socketIO:(SocketIO *)socket didReceiveJSON:(SocketIOPacket *)packet
+{
+    if ([_delegate respondsToSelector:@selector(socketIO:didReceiveJSON:)]) {
+        [_delegate socketIO:socket didReceiveJSON:packet];
+    }
+}
+
+- (void)socketIO:(SocketIO *)socket didReceiveEvent:(SocketIOPacket *)packet
+{
+    if ([_delegate respondsToSelector:@selector(socketIO:didReceiveEvent:)]) {
+        [_delegate socketIO:socket didReceiveEvent:packet];
+    }
+}
+
+- (void)socketIO:(SocketIO *)socket didSendMessage:(SocketIOPacket *)packet
+{
+    if ([_delegate respondsToSelector:@selector(socketIO:didSendMessage:)]) {
+        [_delegate socketIO:socket didSendMessage:packet];
+    }
+}
+
+- (void)socketIO:(SocketIO *)socket onError:(NSError *)error
+{
+    if ([_delegate respondsToSelector:@selector(socketIO:onError:)]) {
+        [_delegate socketIO:socket onError:error];
+    }
+}
+
+@end

--- a/SocketIOPacket.m
+++ b/SocketIOPacket.m
@@ -39,6 +39,8 @@
                   @"error",
                   @"noop",
                   nil];
+
+        self.endpoint = @"";
     }
     return self;
 }

--- a/SocketIO_NSInterface.h
+++ b/SocketIO_NSInterface.h
@@ -1,0 +1,40 @@
+//
+//  SocketIO_NSInterface.h
+//  Pods
+//
+//  Created by jbaez on 04/07/2014.
+//
+//  SocketIO Interface used by SocketIONamespace
+//
+
+#import "SocketIO.h"
+
+@interface SocketIO ()
+
+/// For reusing socket connection with multiple namespaces
+- (void)addNamespaceDelegate:(id<SocketIONamespaceDelegate>) delegate;
+
+- (void)sendMessage:(NSString *)data forNamespace:(NSString *)endpoint;
+
+- (void)sendMessage:(NSString *)data
+       forNamespace:(NSString *)endpoint
+    withAcknowledge:(SocketIOCallback)function;
+
+- (void)sendJSON:(NSDictionary *)data forNamespace:(NSString *)endpoint;
+
+- (void)sendJSON:(NSDictionary *)data
+    forNamespace:(NSString *)endpoint
+ withAcknowledge:(SocketIOCallback)function;
+
+- (void)sendEvent:(NSString *)eventName
+     forNamespace:(NSString *)endpoint
+         withData:(id)data;
+
+- (void)sendEvent:(NSString *)eventName
+     forNamespace:(NSString *)endpoint
+         withData:(id)data
+   andAcknowledge:(SocketIOCallback)function;
+
+- (void)sendConnectForNamespace:(NSString *)endpoint;
+
+@end


### PR DESCRIPTION
The current namespace implementation was not ideal, it would create a new socket connection for each namespace.
In this PR the namespace was removed from SocketIO class.
To share the same socket connection with multiple namespaces the SocketIONamespace class can be used instead.

```
SocketIONamespace *socketNS  = [SocketIONamespace namespaceWithEndpoint:@"/endpoint" delegate:self];
```

Basically SocketIONamespace creates a SocketIO singleton which is reused by all SocketIONamespace instances. SocketIONamespace instances register themselves as a delegate of SocketIO. 
SocketIO will send events/messages only to the matching namespace SocketIONamespace instance.

pd: SocketIO has an array of weak pointers for the namespaces delegates  implemented with a NSPointerArray, which is available on iOS 6 and later.
