### PR TITLE
fix memory increase by autorelease when data send

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -234,19 +234,20 @@ NSString* const SocketIOException = @"SocketIOException";
 - (void) sendEvent:(NSString *)eventName withData:(id)data andAcknowledge:(SocketIOCallback)function
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:eventName forKey:@"name"];
-
-    // do not require arguments
-    if (data != nil) {
-        [dict setObject:[NSArray arrayWithObject:data] forKey:@"args"];
-    }
+    @autoreleasepool {
+        // do not require arguments
+        if (data != nil) {
+            [dict setObject:[NSArray arrayWithObject:data] forKey:@"args"];
+        }
     
-    SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"event"];
-    packet.data = [SocketIOJSONSerialization JSONStringFromObject:dict error:nil];
-    packet.pId = [self addAcknowledge:function];
-    if (function) {
-        packet.ack = @"data";
+        SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"event"];
+        packet.data = [SocketIOJSONSerialization JSONStringFromObject:dict error:nil];
+        packet.pId = [self addAcknowledge:function];
+        if (function) {
+            packet.ack = @"data";
+        }
+        [self send:packet];
     }
-    [self send:packet];
 }
 
 - (void) sendAcknowledgement:(NSString *)pId withArgs:(NSArray *)data 


### PR DESCRIPTION
there are memory increase issue when call 
- (void) sendEvent:(NSString *)eventName withData:(id)data andAcknowledge:(SocketIOCallback)function

passing call release to main autoreleasepool is not good idea when so many sendData called.
so i've added local @autoreleasepool in sendEvent function
