### PR TITLE
Update SocketIO.m

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -237,7 +237,10 @@ NSString* const SocketIOException = @"SocketIOException";
 
     // do not require arguments
     if (data != nil) {
-        [dict setObject:[NSArray arrayWithObject:data] forKey:@"args"];
+        if ( [data isKindOfClass:[NSArray class]])
+            [dict setObject:data forKey:@"args"];   // It's already an array.  Don't re-package it.
+        else
+            [dict setObject:[NSArray arrayWithObject:data] forKey:@"args"];
     }
     
     SocketIOPacket *packet = [[SocketIOPacket alloc] initWithType:@"event"];


### PR DESCRIPTION
sendEvent assumes the incoming data isn't an NSArray already; this causes it to double-wrap NSArray objects (so instead of [data], you end up with [[data]].  Check if the incoming objet is of type NSArray, and if so pass it along verbatim.
